### PR TITLE
Aks extra samples

### DIFF
--- a/samples/azure-aks-disk-encryption.yaml
+++ b/samples/azure-aks-disk-encryption.yaml
@@ -11,7 +11,7 @@ spec:
       - name: default
         nodeCount: 1
         vmSize: Standard_D2_v2
-        diskEncryptionSetId : ExistingDiskEncryptionSetResourceId # replace with existing disk encryption set id
+        diskEncryptionSetId : ExistingDiskEncryptionSetResourceFullId # replace with existing disk encryption set id
     dnsPrefix: akscluster
     identity:
       - type: SystemAssigned

--- a/samples/azure-aks-private-cluster.yaml
+++ b/samples/azure-aks-private-cluster.yaml
@@ -12,7 +12,7 @@ spec:
         nodeCount: 1
         vmSize: Standard_D2_v2
     dnsPrefix: akscluster
-    privateClusterEnabled: true # deploys a private cluster with a private DNS zone
+    privateClusterEnabled: true # Setting to enable private AKS clusters - Defaults to private DNS within the MC group
     identity:
       - type: SystemAssigned
     location: "East US 2" #replace with region 

--- a/samples/azure-aks-vnet.yaml
+++ b/samples/azure-aks-vnet.yaml
@@ -11,7 +11,7 @@ spec:
       - name: default
         nodeCount: 1
         vmSize: Standard_D2_v2
-        vnetSubnetId: ExistingSubnetResourceId # replace with existing subnet id
+        vnetSubnetId: ExistingSubnetResourceId # Setting to use an existing VNET. replace with existing subnet id
     dnsPrefix: akscluster
     identity:
       - type: SystemAssigned


### PR DESCRIPTION
Added three additional samples to deploy the following configurations:

- private AKS clusters
- AKS clusters with existing VNETs
- AKS clusters with an existing Disk Encryption Set